### PR TITLE
Add second machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Dotfiles
 
-These are my [dotfiles](https://dotfiles.github.io), which allow me to codify, automate, and reliably reproduce the configuration of my systems. They use [Nix](https://nixos.org), [nix-darwin](https://github.com/nix-darwin/nix-darwin), and [home-manager](https://github.com/nix-community/home-manager).
+My [dotfiles](https://dotfiles.github.io), which allow me to automate and reliably reproduce the setup of my systems. They use [Nix](https://nixos.org), [nix-darwin](https://github.com/nix-darwin/nix-darwin), and [home-manager](https://github.com/nix-community/home-manager).
 
 ## Organisation
 
-| File                                                       | Purpose                                     |
-| :--------------------------------------------------------- | :------------------------------------------ |
-| [flake.nix](flake.nix)                                     | The entrypoint to my dotfiles.              |
-| [modules/nix-core.nix](modules/nix-core.nix)               | Configuration of Nix.                       |
-| [modules/darwin](modules/darwin/default.nix)               | macOS configuration.                        |
-| [modules/darwin/packages.nix](modules/darwin/packages.nix) | App installation.                           |
-| [modules/home](modules/home/default.nix)                   | Home Manager initialisation.                |
-| [modules/home/emacs.nix](modules/home/emacs.nix)           | Doom Emacs configuration.                   |
-| [modules/home/terminal.nix](modules/home/terminal.nix)     | ZSH, Starship, fzf, bat, etc.               |
-| [modules/home/git.nix](modules/home/git.nix)               | Git configuration.                          |
-| [modules/home/ssh.nix](modules/home/ssh.nix)               | SSH configuration.                          |
+| File                                                                 | Purpose                                              |
+| :------------------------------------------------------------------- | :----------------------------------------------------|
+| [flake.nix](flake.nix)                                               | Entrypoint.                                          |
+| [hosts/](hosts/)                                                     | Host configs.                                        |
+| [hosts/nexus/default.nix](hosts/nexus/default.nix)                   | Host entrypoint.                                     |
+| [hosts/nexus/home.nix](hosts/nexus/home.nix)                         | Host configuration.                                  |
+| [modules/](modules)                                                  | Common functionality.                                |
+| [modules/home-manager/default.nix](modules/home-manager/default.nix) | Home Manager initialisation.                         |
+| [modules/home-manager/programs/](modules/home-manager/programs/)     | Common application configuration.                    |
+| [modules/nix/default.nix](modules/nix/defaalt.nix)                   | Nix configuration.                                   |
+| [modules/nix-darwin/default.nix](modules/nix-darwin/default.nix)     | Common macOS [defaults](https://macos-defaults.com). |
 
 ## Prerequisites
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,38 +1,41 @@
 # Roadmap
 
-* Simplify Install
-  * [ ] Investigate [nix-homebrew](https://github.com/zhaofengli/nix-homebrew) to eliminate the manual Homebrew install step.
+[!NOTE]
+I'm now using [Github Issues](https://github.com/cameronyule/dotfiles/issues) for managing the roadmap.
 
-* Idiomatic Nix
+* [x] ~~Simplify Install~~
+  * [x] ~~Investigate [nix-homebrew](https://github.com/zhaofengli/nix-homebrew) to eliminate the manual Homebrew install step.~~
+
+* [ ] Idiomatic Nix
   * [ ] Favour Nix-managed software over Homebrew Casks and Mac App Store.
-  * [ ] Favour nix-darwin _or_ Home Manager for managing packages, not both.
+  * [x] Favour nix-darwin _or_ Home Manager for managing packages, not both.
 
-* System Configuration
+* [ ] System Configuration
   * [x] ~~Define the full list of software I use in [packages.nix](../modules/packages.nix).~~
-  * [ ] Safari configuration (e.g., Status Bar).
-  * Window Management.
+  * [ ] ~~Safari configuration (e.g., Status Bar).~~
+  * ~~Window Management.~~
     * [x] ~~Investigate [FlashSpace](https://github.com/wojciech-kulik/FlashSpace) as an alternative to [macOS Spaces](https://support.apple.com/en-gb/guide/mac-help/mh14112/mac)~~.
     * [x] ~~Configure tiling window management.~~
-  * Keyboard Configuration
-    * Apply keyboard overrides only to my specific keyboard.
+  * [ ] Keyboard Configuration
+    * [ ] Apply keyboard overrides only to my specific keyboard.
 
-* Development Environment.
-  * Emacs Configuration.
+* [ ] Development Environment.
+  * [ ] Emacs Configuration.
     * [ ] [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) installations.
       * [ ] Elisp (e.g. [Elsa](https://github.com/emacs-elsa/Elsa))
       * [x] ~~Nix~~
       * [x] ~~Rust~~
       * [x] ~~Shell~~
-    * [ ] Debugging Support.
-      * [x] [Doom Debugger](https://github.com/doomemacs/doomemacs/tree/master/modules/tools/debugger)
-    * [ ] Theme
-      * [x] [Solarized](https://github.com/doomemacs/themes/blob/master/themes/doom-solarized-dark-theme.el)
-      * [ ] [svg-tag-mode](https://github.com/rougier/svg-tag-mode)
-      * [x] [Update Fonts](https://github.com/doomemacs/doomemacs/blob/master/docs/faq.org#change-my-fonts)
-  * Evaluate [Nix flakes](https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10), [Direnv](https://nixos.asia/en/direnv), [Devenv](https://devenv.sh/), [Flox](https://github.com/flox/flox), and others.
-    * Evaluate [building containers with Nix](https://xeiaso.net/talks/2024/nix-docker-build/).
-  * Xcode integration with Nix.
-  * Secrets management.
+    * [x] ~~Debugging Support.~~
+      * [x] ~~[Doom Debugger](https://github.com/doomemacs/doomemacs/tree/master/modules/tools/debugger)~~
+    * [x] ~~Theme~~
+      * [x] ~~[Solarized](https://github.com/doomemacs/themes/blob/master/themes/doom-solarized-dark-theme.el)~~
+      * [ ] ~~[svg-tag-mode](https://github.com/rougier/svg-tag-mode)~~
+      * [x] ~~[Update Fonts](https://github.com/doomemacs/doomemacs/blob/master/docs/faq.org#change-my-fonts)~~
+  * [ ] Evaluate [Nix flakes](https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10), [Direnv](https://nixos.asia/en/direnv), [Devenv](https://devenv.sh/), [Flox](https://github.com/flox/flox), and others.
+    * [ ] Evaluate [building containers with Nix](https://xeiaso.net/talks/2024/nix-docker-build/).
+  * [x] ~~Xcode integration with Nix.~~
+  * [ ] ~~Secrets management.~~
     * [x] ~~[Using secrets with 1Password CLI](https://developer.1password.com/docs/cli/secret-references)~~
   * [x] ~~SSH Configuration (SSH keys, SSH agent, etc).~~
   * [x] ~~Terminal Configuration.~~


### PR DESCRIPTION
I only have one machine managed by my dotfiles at the moment, while I was experimenting with Nix. Given this has been a success, I'm now looking to expand my configuration to manage multiple machines. These may have different CPU architectures, different operating systems or versions, and different requirements in terms of how they are configured and which software they have installed.

In the current setup, my dotfiles are organised around system-wide configuration provided by nix-darwin and user-specific configuration provided by Home Manager. I'd like to retain that separation (and improve upon it if possible) while also refactoring around "hosts" as the primary unit of organisation.

Requirements:

* Adding a new machine must not negatively affect the configuration of an existing machine.
* The new machine must be able to diverge its configuration from an existing machine.
* Modules must have no knowledge of machine configuration beyond what they receive through their interface.
* Update documentation to reflect what's changed.

Optional:

* Allow users to be configurable per-machine. E.g., machine X has users [A, B].