### PR TITLE
broken nix-darwin and nix-homebrew integration

### DIFF
--- a/modules/nix-darwin/homebrew.nix
+++ b/modules/nix-darwin/homebrew.nix
@@ -5,6 +5,8 @@
     nix-homebrew.darwinModules.nix-homebrew
   ];
 
+  homebrew.enable = true;
+
   nix-homebrew = {
     enable = true;
     user = "${username}";


### PR DESCRIPTION
following the refactoring work in #11, nix-darwin has stopped running Homebrew installation when `darwin-rebuild` is invoked.

opening this to track resolution.