### PR TITLE
Pin Homebrew taps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1746795192,
-        "narHash": "sha256-Cv+RXuzmn2iGBY2Ny/nXBTH+LFKDWIvMxf9a+btKI6M=",
+        "lastModified": 1749511373,
+        "narHash": "sha256-7u1TdHQaUCzzgf/n8T3bQosuYXyNBEPU/3WQQqozE5o=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f39076b3c2251994419215279d0525ef667fc31",
+        "rev": "7b4ef99fed96966269ee35994407fa4c06097a4d",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.5.2",
+        "ref": "4.5.6",
         "repo": "brew",
         "type": "github"
       }
@@ -34,6 +34,38 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "homebrew-cask": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750619956,
+        "narHash": "sha256-ubsWBxIMJ1fjQ/vZdSVgzWOtEKPJmig6apwg+zLp+Fo=",
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "rev": "a1974d7e4797d404a5abfd31051e1fd963bf811e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "type": "github"
+      }
+    },
+    "homebrew-core": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750624070,
+        "narHash": "sha256-ELtA/e7/kB9Zw3uHM6PGuMc19p/LAXQq3QchV04h+Vs=",
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "rev": "9320cc8f782ed25a53ec5e8e511c6f16c7258888",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-core",
         "type": "github"
       }
     },
@@ -60,20 +92,14 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": "brew-src",
-        "nix-darwin": [
-          "nix-darwin"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1747444109,
-        "narHash": "sha256-fSufrKr8NdhLMuGZGwjGUfH+TIWrjFTRIBhgCRIyxno=",
+        "lastModified": 1749952250,
+        "narHash": "sha256-V2ix0knpdJXirQ+4pjbnggjdSALTsFWGIP/NDpaQkdU=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "159f21ae77da757bbaeb98c0b16ff2e7b2738350",
+        "rev": "37126f06f4890f019af3d7606ce5d30a457afcd0",
         "type": "github"
       },
       "original": {
@@ -101,6 +127,8 @@
     "root": {
       "inputs": {
         "home-manager": "home-manager",
+        "homebrew-cask": "homebrew-cask",
+        "homebrew-core": "homebrew-core",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,11 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
-    nix-homebrew.inputs.nixpkgs.follows = "nixpkgs";
-    nix-homebrew.inputs.nix-darwin.follows = "nix-darwin";
+
+    homebrew-core.url = "github:homebrew/homebrew-core";
+    homebrew-core.flake = false;
+    homebrew-cask.url = "github:homebrew/homebrew-cask";
+    homebrew-cask.flake = false;
   };
 
   outputs =
@@ -21,6 +24,8 @@
       home-manager,
       nix-darwin,
       nix-homebrew,
+      homebrew-core,
+      homebrew-cask,
       nixpkgs,
     }:
     let

--- a/modules/nix-darwin/homebrew.nix
+++ b/modules/nix-darwin/homebrew.nix
@@ -1,15 +1,29 @@
-{ nix-homebrew, username, ... }:
+{ nix-homebrew, homebrew-core, homebrew-cask, username, ... }:
 
 {
   imports = [
     nix-homebrew.darwinModules.nix-homebrew
   ];
 
+  # Enable nix-darwin's management of package management via Homebrew.
   homebrew.enable = true;
 
   nix-homebrew = {
+    # Enable nix-homebrew's management of Homebrew installation.
     enable = true;
+
     user = "${username}";
-    autoMigrate = true;
+
+    autoMigrate = false;
+
+    # Declarative tap management
+    taps = {
+      "homebrew/homebrew-core" = homebrew-core;
+      "homebrew/homebrew-cask" = homebrew-cask;
+    };
+
+    # Enable fully-declarative tap management
+    # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
+    mutableTaps = false;
   };
 }


### PR DESCRIPTION
One of the main benefits of using Nix to manage system config is the ability to pin dependencies. On macOS however it's difficult to avoid installing _some_ dependencies from Homebrew, particularly those which cannot be built from source by Nix (e.g., [Ghostty](https://github.com/NixOS/nixpkgs/issues/388984#issuecomment-2715508998)).

The interaction between Nix and Homebrew in my dotfiles is as follows:

* [nix-homebrew](https://github.com/zhaofengli/nix-homebrew) manages the installation and configuration of Homebrew itself
* [nix-darwin](https://github.com/nix-darwin/nix-darwin) uses that Homebrew installation to manage package installation ([docs](https://nix-darwin.github.io/nix-darwin/manual/#opt-homebrew.enable))

While this worked and was simple to configure, by default the versions of Homebrew formula being used during installation was solely dependent on the time installation occurred (e.g., executing my config one day may install SomeApp 1.0 and the next day, after the Homebrew formula being updated, install SomeApp 1.1). The lack of idempotency meant that my system configs were not reproducible.

nix-homebrew has recently added the ability to pin the Homebrew taps (e.g. [homebrew-core](https://github.com/Homebrew/homebrew-core), [homebrew-cask](https://github.com/Homebrew/homebrew-cask), etc), which solves this problem.